### PR TITLE
Fix a flaky test.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,12 @@
     </distributionManagement>
 
     <dependencies>
+	<dependency>
+            <groupId>net.javacrumbs.json-unit</groupId>
+            <artifactId>json-unit-assertj</artifactId>
+            <version>2.4.0</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>

--- a/src/test/java/com/lazerycode/jmeter/json/TestConfigTest.java
+++ b/src/test/java/com/lazerycode/jmeter/json/TestConfigTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 public class TestConfigTest {
 
@@ -24,7 +25,7 @@ public class TestConfigTest {
         URL configFile = this.getClass().getResource(testConfigFile);
         File testConfigJSON = new File(configFile.toURI());
         TestConfigurationWrapper testConfig = new TestConfigurationWrapper(testConfigJSON, "test-execution");
-        assertThat(testConfig.getFullConfig())
+        assertThatJson(testConfig.getFullConfig())
                 .isEqualTo("{\"executionID\":\"test-execution\",\"jmeterDirectoryPath\":null,\"runtimeJarName\":null,\"resultsOutputIsCSVFormat\":false,\"generateReports\":false,\"resultFilesLocations\":[],\"propertiesMap\":null,\"jmeterWorkingDirectoryPath\":null}");
     }
 


### PR DESCRIPTION
1. The test failure:
- I ran `mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=com.lazerycode.jmeter.json.TestConfigTest#createConfigFromResourceFile` 
  Here are the details of [NonDex](https://github.com/TestingResearchIllinois/NonDex).
- The test `com.lazerycode.jmeter.json.TestConfigTest#createConfigFromResourceFile` fails as follows:
```
at com.lazerycode.jmeter.json.TestConfigTest.createConfigFromResourceFile(TestConfigTest.java:28)
Error: TestConfigTest.createConfigFromResourceFile:28 
expected:<"{"[executionID":"test-execution","jmeterDirectoryPath":null,"runtimeJarName":null,"resultsOutputIsCSVFormat":false,"generateReports":false,"resultFilesLocations":[]],"propertiesMap":nul...> 
but was:<"{"[generateReports":false,"resultsOutputIsCSVFormat":false,"jmeterDirectoryPath":null,"resultFilesLocations":[],"executionID":"test-execution","runtimeJarName":null],"propertiesMap":nul...>
```

2. Why it fails:
- In `src/main/java/com/lazerycode/jmeter/json/TestConfigurationWrapper.java`, `mapper.writeValueAsString(testConfiguration)` serializes Java objects as JSON output, but the order of objects being mapped into a string by ObjectMapper changes.

3. Fix it:
- Here we change `assertThat` to `assertThatJson`, also need to add a dependency for `net.javacrumbs.json-unit`
